### PR TITLE
Drop unnecessary commas

### DIFF
--- a/handler/app.rb
+++ b/handler/app.rb
@@ -28,10 +28,11 @@ def lambda_handler(event:, context:)
     end
     logger.info("address_hash: #{address_hash}")
 
-    # build the joined address
-    joined_address = address_hash.map do |key, value|
-      key == 'aptorunitnum' ? "#{value} " : "#{value},"
-    end.compact.join("")
+    # build the joined address and reject empty elements
+    address_components = address_hash.map do |key, value|
+      key == 'aptorunitnum' ? "#{value} " : "#{value}"
+    end.compact.reject(&:empty?)
+    joined_address = address_components.join(", ")
     logger.info("joined_address: #{joined_address}")
 
     # if the joined address is empty, return an error
@@ -57,6 +58,7 @@ def lambda_handler(event:, context:)
         }
       else
         logger.info("Found #{results.count} results for #{joined_address}")
+        logger.info("Results: #{results.map { |res| res.data }}")
         { statusCode: 200,
           headers: {
             'Content-Type' => 'application/json'

--- a/template.yaml
+++ b/template.yaml
@@ -20,12 +20,12 @@ Resources:
       Runtime: ruby2.7
       Architectures:
         - x86_64
-      Events:
-        GeocodeAddress:
-          Type: Api # More info about API Event Source: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#api
-          Properties:
-            Path: /address-geocoder
-            Method: get
+#      Events:
+#        GeocodeAddress:
+#          Type: Api # More info about API Event Source: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#api
+#          Properties:
+#            Path: /address-geocoder
+#            Method: get
 
 Outputs:
   # ServerlessRestApi is an implicit API created out of Events key under Serverless::Function


### PR DESCRIPTION
If we only sent the required fields as queryStringParams from the UI, commas from the values of the empty fields would be joined in the string before we geocoded it, defeating the purpose. 

This is no longer happening, now we are dropping empty elements.